### PR TITLE
Time is missing in the simulate callback

### DIFF
--- a/daynightoverlay/examples/params.html
+++ b/daynightoverlay/examples/params.html
@@ -34,7 +34,7 @@
                         from.getUTCFullYear() + ' - 00:00 UTC';
 
                     dno.setDate(from);
-                    setTimeout(function() { simulate(from, to, step); }, time);
+                    setTimeout(function() { simulate(from, to, step, time); }, time);
                 }
             }
         </script>


### PR DESCRIPTION
Hi, I was trying to adjust the time period between animation frames and nothing was happening, so I noticed that the time argument was missing from the simulate call in setTimeout function.
