### PR TITLE
Fixed small bug

### DIFF
--- a/panomarker/src/panomarker.js
+++ b/panomarker/src/panomarker.js
@@ -1,4 +1,3 @@
-
 /**
  * PanoMarker
  * Version 0.0
@@ -269,8 +268,10 @@ PanoMarker.prototype.draw = function() {
       this.pano_.getPov(),
       this.pano_.getContainer());
 
-  this.marker_.style.left = (offset.left - this.anchor_.x) + 'px';
-  this.marker_.style.top = (offset.top - this.anchor_.y) + 'px';
+  if( offset !== null ){
+    this.marker_.style.left = (offset.left - this.anchor_.x) + 'px';
+    this.marker_.style.top = (offset.top - this.anchor_.y) + 'px';
+  }
 };
 
 


### PR DESCRIPTION
When:

var t = nDotC / nDotD;

if (t < 0.0) {
   return null;
}

the position can't be calculated, because "null" has no property "left" and "top", also the marker is out of sighs and don't have to be calculated.
