### PR TITLE
Moved povToPixel assignment to top of constructor

### DIFF
--- a/panomarker/src/panomarker.js
+++ b/panomarker/src/panomarker.js
@@ -80,9 +80,20 @@
  * @extends google.maps.OverlayView
  */
 var PanoMarker = function(opts) {
+
   // In case no options have been given at all, fallback to {} so that the
   // following won't throw errors.
   opts = opts || {};
+
+  /**
+   * Currently only Chrome is rendering panoramas in a 3D sphere. The other
+   * browsers are just showing the raw panorama tiles and pan them around.
+   *
+   * @private
+   * @type {function(StreetViewPov, StreetViewPov, number, Element): Object}
+   */
+  this.povToPixel_ = !!window.chrome ? PanoMarker.povToPixel3d :
+      PanoMarker.povToPixel2d;
 
   /** @private @type {google.maps.Point} */
   this.anchor_ = opts.anchor || new google.maps.Point(16, 16);
@@ -131,16 +142,6 @@ var PanoMarker = function(opts) {
 
   // At last, call some methods which use the initialized parameters
   this.setPano(opts.pano || null);
-
-  /**
-   * Currently only Chrome is rendering panoramas in a 3D sphere. The other
-   * browsers are just showing the raw panorama tiles and pan them around.
-   *
-   * @private
-   * @type {function(StreetViewPov, StreetViewPov, number, Element): Object}
-   */
-  this.povToPixel_ = !!window.chrome ? PanoMarker.povToPixel3d :
-      PanoMarker.povToPixel2d;
 };
 
 PanoMarker.prototype = new google.maps.OverlayView();


### PR DESCRIPTION
In some instances, when `setPano()` is called at the end of the constructor, an error would is thrown because `povToPixel` is called in the `draw` function, but is not yet defined.

This change moves the assignment to the top of the constructor before any `draw` call.